### PR TITLE
Implement navigation and bottom bar

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ASMSmaliIdeaPluginConfiguration">
     <asm skipDebug="true" skipFrames="true" skipCode="false" expandFrames="false" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    kotlin("plugin.serialization") version "2.1.10"
+
 }
 
 android {
@@ -44,7 +46,9 @@ dependencies {
     implementation("com.airbnb.android:lottie-compose:6.0.0")
 
     //navigation
-    implementation("androidx.navigation:navigation-compose:2.7.5")
+    implementation ("androidx.navigation:navigation-compose:2.4.0-alpha06")
+    implementation ("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
+
 
 
     implementation(libs.androidx.core.ktx)

--- a/app/src/main/java/com/example/weathersync/MainActivity.kt
+++ b/app/src/main/java/com/example/weathersync/MainActivity.kt
@@ -1,26 +1,21 @@
 package com.example.weathersync
 
 import android.os.Bundle
-import android.view.View
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import com.example.weathersync.ui.screens.*
+import androidx.core.view.WindowCompat
+import com.example.weathersync.navigation.SetupNavHost
 import com.example.weathersync.ui.theme.WeatherSyncTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        window.apply {
-            decorView.systemUiVisibility = (
-                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
-                            View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                    )
-            statusBarColor = android.graphics.Color.TRANSPARENT
-        }
+
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         setContent {
             WeatherSyncTheme {
-                HomeScreen()
+                SetupNavHost()
             }
         }
     }

--- a/app/src/main/java/com/example/weathersync/navigation/BottomNavItem.kt
+++ b/app/src/main/java/com/example/weathersync/navigation/BottomNavItem.kt
@@ -1,0 +1,9 @@
+package com.example.weathersync.navigation
+
+import androidx.compose.ui.graphics.vector.ImageVector
+
+data class BottomNavItem(
+    val label: String,
+    val icon: ImageVector,
+    val route: String
+)

--- a/app/src/main/java/com/example/weathersync/navigation/BottomNavigationBar.kt
+++ b/app/src/main/java/com/example/weathersync/navigation/BottomNavigationBar.kt
@@ -1,0 +1,112 @@
+package com.example.weathersync.navigation
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.example.weathersync.R
+import com.example.weathersync.ui.theme.DeepNavyBlue
+import com.example.weathersync.ui.theme.LightSeaGreen
+
+@Composable
+fun BottomNavigationBar(navController: NavHostController) {
+    val items = listOf(
+        BottomNavItem(
+            label = stringResource(R.string.home),
+            icon = Icons.Default.Home,
+            route = ScreenRoute.HomeScreenRoute.route
+        ),
+        BottomNavItem(
+            label = stringResource(R.string.favorites),
+            icon = Icons.Default.Favorite,
+            route = ScreenRoute.FavoritesScreenRoute.route
+        ),
+        BottomNavItem(
+            label = stringResource(R.string.alerts),
+            icon = Icons.Default.Notifications,
+            route = ScreenRoute.NotificationsScreenRoute.route
+        ),
+        BottomNavItem(
+            label = stringResource(R.string.settings),
+            icon = Icons.Default.Settings,
+            route = ScreenRoute.SettingsScreenRoute.route
+        )
+    )
+
+    val backgroundColor = if (isSystemInDarkTheme()) DeepNavyBlue else LightSeaGreen
+    val backStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = backStackEntry?.destination?.route
+
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .padding(horizontal = 4.dp),
+        shape = RoundedCornerShape(32.dp),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 0.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.Black.copy(alpha = 0.1f))
+        ) {
+            NavigationBar(
+                containerColor = Color.Transparent,
+                contentColor = Color.White,
+            ) {
+                items.forEach { item ->
+                    val selected = item.route == currentDestination
+
+                    NavigationBarItem(
+                        selected = selected,
+                        onClick = {
+                            navController.navigate(item.route) {
+                                launchSingleTop = true
+                                restoreState = true
+                                popUpTo(navController.graph.startDestinationId) {
+                                    saveState = true
+                                }
+                            }
+                        },
+                        icon = {
+                            Icon(
+                                imageVector = item.icon,
+                                contentDescription = item.label,
+                            )
+                        },
+                        label = {
+                            Text(
+                                text = item.label,
+                                maxLines = 1,
+                            )
+                        },
+                        colors = NavigationBarItemDefaults.colors(
+                            selectedIconColor = backgroundColor,
+                            selectedTextColor = Color.White,
+                            indicatorColor = Color.White,
+                            unselectedIconColor = Color.White,
+                            unselectedTextColor = Color.White
+                        )
+                    )
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/example/weathersync/navigation/NavHost.kt
+++ b/app/src/main/java/com/example/weathersync/navigation/NavHost.kt
@@ -1,0 +1,57 @@
+package com.example.weathersync.navigation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.*
+import com.example.weathersync.ui.screens.*
+import com.example.weathersync.ui.theme.DeepNavyBlue
+import com.example.weathersync.ui.theme.LightSeaGreen
+
+@Composable
+fun SetupNavHost() {
+    val navController = rememberNavController()
+
+    Scaffold(
+        bottomBar = {
+            if (navController.currentBackStackEntryAsState().value?.destination?.route != ScreenRoute.SplashScreenRoute.route) {
+                val backgroundColor = if (isSystemInDarkTheme()) DeepNavyBlue else LightSeaGreen
+                Box(
+                    modifier = Modifier
+                        .padding(bottom = 4.dp)
+                        .background(backgroundColor)
+                ) {
+                    BottomNavigationBar(navController = navController)
+                }
+            }
+        }
+    ) {innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = ScreenRoute.SplashScreenRoute.route,
+            modifier = Modifier.padding(innerPadding)
+        ) {
+            composable(ScreenRoute.SplashScreenRoute.route) {
+                SplashScreen(navController)
+            }
+            composable(ScreenRoute.HomeScreenRoute.route) {
+                HomeScreen(navController)
+            }
+            composable(ScreenRoute.FavoritesScreenRoute.route) {
+                FavoritesScreen()
+            }
+            composable(ScreenRoute.NotificationsScreenRoute.route) {
+                NotificationsScreen()
+            }
+            composable(ScreenRoute.SettingsScreenRoute.route) {
+                SettingsScreen()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/weathersync/navigation/ScreenRoute.kt
+++ b/app/src/main/java/com/example/weathersync/navigation/ScreenRoute.kt
@@ -1,0 +1,21 @@
+package com.example.weathersync.navigation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed class ScreenRoute(val route: String) {
+    @Serializable
+    object SplashScreenRoute : ScreenRoute("splash_screen")
+
+    @Serializable
+    object HomeScreenRoute : ScreenRoute("home_screen")
+
+    @Serializable
+    object FavoritesScreenRoute : ScreenRoute("favorites_screen")
+
+    @Serializable
+    object SettingsScreenRoute : ScreenRoute("settings_screen")
+
+    @Serializable
+    object NotificationsScreenRoute : ScreenRoute("notifications_screen")
+}

--- a/app/src/main/java/com/example/weathersync/ui/screens/FavoritesScreen.kt
+++ b/app/src/main/java/com/example/weathersync/ui/screens/FavoritesScreen.kt
@@ -1,0 +1,9 @@
+package com.example.weathersync.ui.screens
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun FavoritesScreen(){
+    Text(text = "Favorites Screen")
+}

--- a/app/src/main/java/com/example/weathersync/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/weathersync/ui/screens/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.example.weathersync.ui.screens
 
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -10,11 +11,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Notifications
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -26,20 +22,22 @@ import androidx.compose.ui.tooling.preview.Devices.PIXEL_5
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
 import com.airbnb.lottie.compose.*
 import com.example.weathersync.R
+import com.example.weathersync.navigation.BottomNavigationBar
 import com.example.weathersync.ui.theme.DeepNavyBlue
 import com.example.weathersync.ui.theme.LightSeaGreen
 
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun HomeScreen() {
+fun HomeScreen(navController: NavHostController) {
     val isDarkMode = isSystemInDarkTheme()
     val backgroundColor = if (isDarkMode) DeepNavyBlue else LightSeaGreen
 
     Scaffold(
-        bottomBar = { BottomNavigationBar() },
         containerColor = backgroundColor
-    ) { paddingValues ->
+    ) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -47,17 +45,14 @@ fun HomeScreen() {
         ) {
             LottieBackground()
             Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
+                modifier = Modifier.fillMaxSize()
             ) {
-                WeatherContent(
-                    modifier = Modifier.weight(1f)
-                )
+                HomeScreenContent(navController)
             }
         }
     }
 }
+
 
 
 @Composable
@@ -80,9 +75,9 @@ fun LottieBackground() {
 }
 
 @Composable
-fun WeatherContent(modifier: Modifier = Modifier) {
+fun HomeScreenContent(navController: NavHostController) {
     LazyColumn(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxSize()
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
@@ -209,7 +204,6 @@ fun DayFeelsLike(weatherCondition: String, feelsLikeTemp: String, iconRes: Int, 
         }
     }
 }
-
 
 @Composable
 fun TemperatureDisplay(temperature: String,type: String) {
@@ -388,7 +382,8 @@ fun NextDaysForecast() {
             ElevatedCard(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(4.dp),
+                    .padding(4.dp)
+                    .border(1.dp, Color.White, RoundedCornerShape(14.dp)),
                 shape = RoundedCornerShape(16.dp),
                 elevation = CardDefaults.elevatedCardElevation(defaultElevation = 0.dp),
                 colors = CardDefaults.cardColors(containerColor = Color.Black.copy(alpha = 0.1f))
@@ -425,53 +420,9 @@ fun NextDaysForecast() {
     }
 }
 
-@Composable
-fun BottomNavigationBar() {
-    val backgroundColor = if (isSystemInDarkTheme()) Color.Black else Color.White
-
-    Card(
-        shape = RoundedCornerShape(24.dp),
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp),
-        colors = CardDefaults.cardColors(backgroundColor),
-        elevation = CardDefaults.elevatedCardElevation(8.dp)
-    ) {
-        NavigationBar(
-            containerColor = backgroundColor,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            NavigationBarItem(
-                icon = { Icon(Icons.Filled.Home, contentDescription = "Home") },
-                label = { Text(text = "Home", maxLines = 1) },
-                selected = true,
-                onClick = {}
-            )
-            NavigationBarItem(
-                icon = { Icon(Icons.Filled.Favorite, contentDescription = "Favorite") },
-                label = { Text(text = "Favorite", maxLines = 1) },
-                selected = false,
-                onClick = {}
-            )
-            NavigationBarItem(
-                icon = { Icon(Icons.Filled.Notifications, contentDescription = "Notifications") },
-                label = { Text(text = "Notification", maxLines = 1) },
-                selected = false,
-                onClick = {}
-            )
-            NavigationBarItem(
-                icon = { Icon(Icons.Filled.Settings, contentDescription = "Settings") },
-                label = { Text(text = "Settings", maxLines = 1) },
-                selected = false,
-                onClick = {}
-            )
-        }
-    }
-}
-
 
 @Preview(showBackground = true, showSystemUi = true, device = PIXEL_5)
 @Composable
 fun HomeScreenPreview() {
-    HomeScreen()
+    //HomeScreen()
 }

--- a/app/src/main/java/com/example/weathersync/ui/screens/NotificationsScreen.kt
+++ b/app/src/main/java/com/example/weathersync/ui/screens/NotificationsScreen.kt
@@ -1,0 +1,9 @@
+package com.example.weathersync.ui.screens
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun NotificationsScreen() {
+    Text(text = "Notifications Screen")
+}

--- a/app/src/main/java/com/example/weathersync/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/weathersync/ui/screens/SettingsScreen.kt
@@ -1,0 +1,9 @@
+package com.example.weathersync.ui.screens
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun SettingsScreen() {
+    Text(text = "Settings Screen")
+}

--- a/app/src/main/java/com/example/weathersync/ui/screens/SplashScreen.kt
+++ b/app/src/main/java/com/example/weathersync/ui/screens/SplashScreen.kt
@@ -17,14 +17,16 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
 import com.airbnb.lottie.compose.*
 import com.example.weathersync.R
+import com.example.weathersync.navigation.ScreenRoute
 import com.example.weathersync.ui.theme.DeepNavyBlue
 import com.example.weathersync.ui.theme.LightSeaGreen
 import kotlinx.coroutines.delay
 
 @Composable
-fun SplashScreen() {
+fun SplashScreen(navController: NavHostController) {
     val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.splash_animation))
     val progress by animateLottieCompositionAsState(
         composition = composition,
@@ -37,6 +39,9 @@ fun SplashScreen() {
         delay(1500)
         showText = true
         delay(1500)
+        navController.navigate(ScreenRoute.HomeScreenRoute.route) {
+            popUpTo(ScreenRoute.SplashScreenRoute.route) { inclusive = true }
+        }
     }
 
     val textAlpha by animateFloatAsState(
@@ -75,5 +80,5 @@ fun SplashScreen() {
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun SplashScreenPreview() {
-    SplashScreen()
+   // SplashScreen()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,9 @@
 <resources>
     <string name="app_name">WeatherSync</string>
     <string name="appName">WeatherSync</string>
+    <string name="home">Home</string>
+    <string name="favorites">Favorites</string>
+    <string name="notifications">Notifications</string>
+    <string name="settings">Settings</string>
+    <string name="alerts">Alerts</string>
 </resources>


### PR DESCRIPTION
This commit introduces a navigation system with a bottom navigation bar.
It implements four screens: Home, Favorites, Notifications, and Settings.
The bottom navigation bar allows users to switch between these screens.
The splash screen will navigate to the home screen after it finish animation.
*   Add `BottomNavigationBar` composable.
*   Add `HomeScreen`, `FavoritesScreen`, `NotificationsScreen`, and `SettingsScreen` composables.
*   Add `SetupNavHost` composable.
* Add `ScreenRoute` class to define routes for each screen.
* Update `SplashScreen` composable.
* Update `HomeScreen` composable.
* Add `BottomNavItem` class to define the structure of each item in the bottom bar.
* Update dependencies.
* Update `MainActivity` composable.
* Update app strings.