### PR TITLE
Refactor: Enhance Search Screen and Integrate with Google Place API

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,7 +91,8 @@ dependencies {
     //google maps
     implementation("com.google.maps.android:maps-compose:4.3.0")
     implementation("com.google.android.gms:play-services-maps:18.2.0")
-    implementation("com.google.android.libraries.places:places:3.3.0")
+    implementation("com.google.maps.android:places-compose:0.1.3")
+    implementation("com.google.android.libraries.places:places:3.4.0")
 
 
 

--- a/app/src/main/java/com/example/weathersync/data/model/remote/PlaceData.kt
+++ b/app/src/main/java/com/example/weathersync/data/model/remote/PlaceData.kt
@@ -1,0 +1,10 @@
+package com.example.weathersync.data.model.remote
+
+import com.google.android.gms.maps.model.LatLng
+
+data class PlaceData(
+    val placeId: String,
+    val displayName: String?,
+    val latLng: LatLng? = null,
+    val address: String? = null
+)

--- a/app/src/main/java/com/example/weathersync/data/remote/RemoteDataSource.kt
+++ b/app/src/main/java/com/example/weathersync/data/remote/RemoteDataSource.kt
@@ -6,6 +6,6 @@ import com.example.weathersync.data.model.remote.ForecastResponse
 import kotlinx.coroutines.flow.Flow
 
 interface RemoteDataSource {
-    fun getWeatherForecast (lat: Double, lon: Double): Flow<Response<ForecastResponse>>
-    fun getWeatherCurrent (lat: Double, lon: Double): Flow<Response<CurrentWeatherResponse>>
+    fun getWeatherForecast(lat: Double, lon: Double): Flow<Response<ForecastResponse>>
+    fun getWeatherCurrent(lat: Double, lon: Double): Flow<Response<CurrentWeatherResponse>>
 }

--- a/app/src/main/java/com/example/weathersync/data/remote/RetrofitClient.kt
+++ b/app/src/main/java/com/example/weathersync/data/remote/RetrofitClient.kt
@@ -1,12 +1,12 @@
 package com.example.weathersync.data.remote
 
-import com.example.weathersync.utils.BASE_URL
+import com.example.weathersync.utils.WEATHER_BASE_URL
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 object RetrofitClient {
     val instance: WeatherApiService = Retrofit.Builder()
-        .baseUrl(BASE_URL)
+        .baseUrl(WEATHER_BASE_URL)
         .addConverterFactory(GsonConverterFactory.create())
         .build()
         .create(WeatherApiService::class.java)

--- a/app/src/main/java/com/example/weathersync/navigation/NavHost.kt
+++ b/app/src/main/java/com/example/weathersync/navigation/NavHost.kt
@@ -16,6 +16,8 @@ import com.example.weathersync.ui.theme.DeepNavyBlue
 import com.example.weathersync.ui.theme.LightSeaGreen
 import com.example.weathersync.viewmodel.FavoriteViewModel
 import com.example.weathersync.viewmodel.FavoriteViewModelFactory
+import com.example.weathersync.viewmodel.SearchViewModel
+import com.example.weathersync.viewmodel.SearchViewModelFactory
 import com.example.weathersync.viewmodel.WeatherViewModel
 import com.example.weathersync.viewmodel.WeatherViewModelFactory
 
@@ -27,6 +29,9 @@ fun SetupNavHost() {
     )
     val favoriteViewModel: FavoriteViewModel = viewModel(
         factory = FavoriteViewModelFactory(LocalContext.current)
+    )
+    val searchViewModel: SearchViewModel = viewModel(
+        factory = SearchViewModelFactory(LocalContext.current)
     )
 
     Scaffold(
@@ -63,11 +68,25 @@ fun SetupNavHost() {
             composable(ScreenRoute.SettingsScreenRoute.route) {
                 SettingsScreen()
             }
-            composable(ScreenRoute.MapScreenRoute.route) {
-                MapScreen(navController, favoriteViewModel)
+
+            composable(
+                route = ScreenRoute.MapScreenRoute.route + "?lat={lat}&lon={lon}",
+                arguments = listOf(
+                    navArgument("lat") { nullable = true; defaultValue = null },
+                    navArgument("lon") { nullable = true; defaultValue = null }
+                )
+            ) { backStackEntry ->
+                val lat = backStackEntry.arguments?.getString("lat")?.toDoubleOrNull()
+                val lon = backStackEntry.arguments?.getString("lon")?.toDoubleOrNull()
+                MapScreen(navController, favoriteViewModel, lat, lon)
             }
+
+            composable(ScreenRoute.MapScreenRoute.route) {
+                MapScreen(navController, favoriteViewModel, null, null)
+            }
+
             composable(ScreenRoute.SearchScreenRoute.route) {
-                SearchScreen(navController)
+                SearchScreen(navController, searchViewModel)
             }
         }
     }

--- a/app/src/main/java/com/example/weathersync/navigation/ScreenRoute.kt
+++ b/app/src/main/java/com/example/weathersync/navigation/ScreenRoute.kt
@@ -20,7 +20,15 @@ sealed class ScreenRoute(val route: String) {
     object AlertsScreenRoute : ScreenRoute("alerts_screen")
 
     @Serializable
-    object MapScreenRoute : ScreenRoute("map_screen")
+    object MapScreenRoute : ScreenRoute("map_screen") {
+        fun createRoute(lat: Double?, lon: Double?): String {
+            return if (lat != null && lon != null) {
+                "map_screen?lat=$lat&lon=$lon"
+            } else {
+                "map_screen"
+            }
+        }
+    }
 
     @Serializable
     object SearchScreenRoute : ScreenRoute("search_screen")

--- a/app/src/main/java/com/example/weathersync/ui/components/SearchResultItem.kt
+++ b/app/src/main/java/com/example/weathersync/ui/components/SearchResultItem.kt
@@ -2,11 +2,11 @@ package com.example.weathersync.ui.components
 
 import com.example.weathersync.R
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Card
@@ -14,29 +14,58 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun SearchResultItem(result: String){
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp),
-        elevation = CardDefaults.cardElevation(4.dp)
-    ) {
-        Row(modifier = Modifier.padding(16.dp)) {
-            Image(
-                painter = painterResource(id = R.drawable.ic_location_pin),
-                contentDescription = stringResource(R.string.location_icon)
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = result,
-                style = MaterialTheme.typography.bodyMedium
-            )
+fun SearchResultItem(address: String, onClick: () -> Unit) {
+    val isArabic = address.any { it in 'ء'..'ي' }
+
+    CompositionLocalProvider(LocalLayoutDirection provides if (isArabic) LayoutDirection.Rtl else LayoutDirection.Ltr) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+            elevation = CardDefaults.elevatedCardElevation(4.dp),
+            onClick = onClick
+        ) {
+            Row(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.Start
+            ) {
+                if (!isArabic) {
+                    Image(
+                        painter = painterResource(id = R.drawable.ic_location_pin),
+                        contentDescription = stringResource(R.string.location_icon)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+
+                Text(
+                    text = address,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (isSystemInDarkTheme()) Color.White else Color.Black,
+                    textAlign = if (isArabic) TextAlign.Right else TextAlign.Left,
+                    modifier = Modifier.weight(1f)
+                )
+
+                if (isArabic) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Image(
+                        painter = painterResource(id = R.drawable.ic_location_pin),
+                        contentDescription = stringResource(R.string.location_icon)
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/weathersync/ui/screens/MapScreen.kt
+++ b/app/src/main/java/com/example/weathersync/ui/screens/MapScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.navigation.NavController
 import com.example.weathersync.R
+import com.example.weathersync.ui.components.AnimatedSnackBar
 import com.example.weathersync.ui.components.BottomSheetContent
 import com.example.weathersync.ui.theme.DeepNavyBlue
 import com.example.weathersync.ui.theme.LightSeaGreen
@@ -33,23 +34,36 @@ import com.google.android.gms.maps.model.MarkerOptions
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MapScreen(navController: NavController, favoriteViewModel: FavoriteViewModel) {
+fun MapScreen(
+    navController: NavController,
+    favoriteViewModel: FavoriteViewModel,
+    lat: Double?,
+    lon: Double?
+) {
     val context = LocalContext.current
     val activity = remember { context as? Activity }
     val mapView = rememberMapViewWithLifecycle()
     val locationProvider = remember { LocationProvider(context) }
     var selectedLocation by remember { mutableStateOf<LatLng?>(null) }
     var userLocation by remember { mutableStateOf<LatLng?>(null) }
+    var marker by remember { mutableStateOf<Marker?>(null) }
     val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var showBottomSheet by remember { mutableStateOf(false) }
+    var snackbarMessage by remember { mutableStateOf<String?>(null) }
+    val initialLocation = lat?.let { LatLng(it, lon ?: 0.0) }
 
     LaunchedEffect(Unit) {
-        activity?.let {
-            locationProvider.getUserLocation(
-                callback = { lat, lon -> userLocation = LatLng(lat, lon) },
-                onError = { Log.e("LocationError", it) },
-                activity = it
-            )
+        if (initialLocation != null) {
+            selectedLocation = initialLocation
+            showBottomSheet = true
+        } else {
+            activity?.let {
+                locationProvider.getUserLocation(
+                    callback = { userLat, userLon -> userLocation = LatLng(userLat, userLon) },
+                    onError = { Log.e("LocationError", it) },
+                    activity = it
+                )
+            }
         }
     }
 
@@ -84,13 +98,15 @@ fun MapScreen(navController: NavController, favoriteViewModel: FavoriteViewModel
                 )
             }
         }
-
+        AnimatedSnackBar(message = snackbarMessage)
         AndroidView(
             factory = { mapView },
             modifier = Modifier.fillMaxSize()
         ) { mapView ->
             mapView.getMapAsync { googleMap ->
-                setupMap(googleMap, userLocation, selectedLocation) { newLocation ->
+                setupMap(googleMap, initialLocation?: userLocation, selectedLocation) { newLocation, newMarker ->
+                    marker?.remove()
+                    marker = newMarker
                     selectedLocation = newLocation
                     showBottomSheet = true
                 }
@@ -108,6 +124,7 @@ fun MapScreen(navController: NavController, favoriteViewModel: FavoriteViewModel
                         Log.d("MapScreen", "Saved Location: ${selectedLocation!!.latitude}, ${selectedLocation!!.longitude}")
                         favoriteViewModel.insertFavorite(selectedLocation?.latitude, selectedLocation?.longitude)
                         showBottomSheet = false
+                        snackbarMessage = "Location Saved Successfully"
                     }
                 )
             }
@@ -119,7 +136,7 @@ private fun setupMap(
     googleMap: GoogleMap,
     userLocation: LatLng?,
     selectedLocation: LatLng?,
-    onLocationSelected: (LatLng) -> Unit
+    onLocationSelected: (LatLng, Marker) -> Unit
 ) {
     googleMap.uiSettings.isZoomControlsEnabled = true
     googleMap.uiSettings.isMyLocationButtonEnabled = true
@@ -129,16 +146,16 @@ private fun setupMap(
 
     googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(locationToShow, 12f))
 
-    var marker: Marker? = null
+    googleMap.clear()
 
     selectedLocation?.let {
-        marker = googleMap.addMarker(MarkerOptions().position(it).title("Selected Location"))
+        googleMap.addMarker(MarkerOptions().position(it).title("Selected Location"))
     }
 
     googleMap.setOnMapClickListener { latLng ->
-        marker?.remove()
-        marker = googleMap.addMarker(MarkerOptions().position(latLng).title("Selected Location"))
-        onLocationSelected(latLng)
+        googleMap.clear()
+        val clickedMarker = googleMap.addMarker(MarkerOptions().position(latLng).title("Selected Location"))
+        onLocationSelected(latLng, clickedMarker!!)
     }
 }
 

--- a/app/src/main/java/com/example/weathersync/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/example/weathersync/ui/screens/SearchScreen.kt
@@ -1,78 +1,135 @@
 package com.example.weathersync.ui.screens
 
+import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.example.weathersync.R
+import com.example.weathersync.data.model.Response
+import com.example.weathersync.data.model.remote.PlaceData
+import com.example.weathersync.navigation.ScreenRoute.MapScreenRoute
 import com.example.weathersync.ui.components.SearchBar
 import com.example.weathersync.ui.components.SearchResultItem
+import com.example.weathersync.ui.theme.DeepNavyBlue
+import com.example.weathersync.ui.theme.LightSeaGreen
+import com.example.weathersync.viewmodel.SearchViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SearchScreen(navController: NavController) {
+fun SearchScreen(navController: NavController, searchViewModel: SearchViewModel) {
     var searchQuery by remember { mutableStateOf(TextFieldValue("")) }
-    var searchResults by remember { mutableStateOf(listOf<String>()) }
-    val coroutineScope = rememberCoroutineScope()
+    val searchResults by searchViewModel.places.collectAsStateWithLifecycle(initialValue = Response.Loading)
+    val message by searchViewModel.message.collectAsStateWithLifecycle(initialValue = "")
+    val scope = rememberCoroutineScope()
 
-    Row (
-        modifier = Modifier.fillMaxSize()
-    ) {
-        IconButton(
-            onClick = { navController.popBackStack() },
-            modifier = Modifier
-                .padding(vertical = 8.dp)
-                .size(40.dp)
+
+    LaunchedEffect(searchQuery.text) {
+        searchViewModel.updateSearchQuery(searchQuery.text)
+    }
+
+    Column (
+        modifier = Modifier
+            .fillMaxSize()
+            .background(if (isSystemInDarkTheme()) DeepNavyBlue else LightSeaGreen),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ){
+        Row(
+            modifier = Modifier.fillMaxWidth()
         ) {
-            Icon(
-                imageVector = Icons.Default.ArrowBack,
-                contentDescription = stringResource(R.string.back),
-                tint = Color.White,
+            IconButton(
+                onClick = { navController.popBackStack() },
                 modifier = Modifier
-                    .size(32.dp)
-                    .padding(start = 4.dp)
+                    .padding(vertical = 8.dp)
+                    .size(40.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.ArrowBack,
+                    contentDescription = stringResource(R.string.back),
+                    tint = Color.White,
+                    modifier = Modifier
+                        .size(32.dp)
+                        .padding(start = 4.dp)
+                )
+            }
+            SearchBar(
+                searchQuery = searchQuery,
+                onQueryChange = { newQuery ->
+                    searchQuery = newQuery
+                }
             )
         }
-        SearchBar(
-            searchQuery = searchQuery,
-            onQueryChange = { newQuery ->
-                searchQuery = newQuery
-                coroutineScope.launch {
-                    searchResults = if (newQuery.text.isNotEmpty()) {
-                        TODO("Implement search logic")
-                    } else {
-                        emptyList()
+        Spacer(modifier = Modifier.height(16.dp))
+
+        when (searchResults) {
+            is Response.Loading -> {
+                CircularProgressIndicator(
+                    color = if (isSystemInDarkTheme()) LightSeaGreen else DeepNavyBlue
+                )
+            }
+
+            is Response.Success -> {
+                val results = (searchResults as Response.Success<List<PlaceData>>).data
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(results.size) { index ->
+                        val place = results[index]
+                        Log.d("SearchScreen", "Result at index $index: ${place.displayName}")
+
+                        SearchResultItem(
+                            address = place.address ?: "Unknown",
+                            onClick = {
+                                Log.d("SearchScreen", "Clicked on result: ${place.displayName}")
+                                scope.launch {
+                                    val location = searchViewModel.fetchPlaceDetails(place.placeId)
+                                    location?.let {
+                                        navController.navigate(MapScreenRoute.createRoute(it.first, it.second))
+                                    }
+                                    Log.d("SearchScreen", "Fetched location: Lat: ${location?.first}, Lng: ${location?.second}")
+                                }
+                            }
+                        )
                     }
                 }
             }
-        )
-        Spacer(modifier = Modifier.height(16.dp))
 
-        LazyColumn(modifier = Modifier.fillMaxSize()) {
-            items(searchResults.size) { index ->
-                SearchResultItem(result = searchResults[index])
+            is Response.Failure -> {
+                val errorMessage = (searchResults as Response.Failure).error.message ?: "Unknown error"
+                Text(
+                    text = "Error: $errorMessage",
+                    color = Color.Red,
+                )
             }
-
         }
-
     }
 }
+
 
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun SearchScreenPreview() {
     val fakeNavController = rememberNavController()
-    SearchScreen(navController = fakeNavController)
+    val fakeSearchViewModel = SearchViewModel(
+        context = fakeNavController.context,
+    )
+    SearchScreen(navController = fakeNavController, searchViewModel = fakeSearchViewModel)
 }
+
 

--- a/app/src/main/java/com/example/weathersync/utils/Constants.kt
+++ b/app/src/main/java/com/example/weathersync/utils/Constants.kt
@@ -2,6 +2,6 @@ package com.example.weathersync.utils
 
 import com.example.weathersync.BuildConfig
 
-const val BASE_URL = "https://api.openweathermap.org/"
+const val WEATHER_BASE_URL = "https://api.openweathermap.org/"
 const val API_KEY = BuildConfig.WEATHER_API_KEY
 const val PLACES_API_KEY = BuildConfig.PLACES_API_KEY

--- a/app/src/main/java/com/example/weathersync/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/example/weathersync/viewmodel/SearchViewModel.kt
@@ -1,0 +1,109 @@
+package com.example.weathersync.viewmodel
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.weathersync.data.model.Response
+import com.example.weathersync.data.model.remote.PlaceData
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.libraries.places.api.Places
+import com.google.android.libraries.places.api.model.*
+import com.google.android.libraries.places.api.net.FetchPlaceRequest
+import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest
+import com.google.android.libraries.places.api.net.PlacesClient
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+
+class SearchViewModel(context: Context) : ViewModel() {
+
+    private val placesClient: PlacesClient = Places.createClient(context)
+    private val sessionToken = AutocompleteSessionToken.newInstance()
+
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    private val _places = MutableSharedFlow<Response<List<PlaceData>>>(replay = 1)
+    val places: SharedFlow<Response<List<PlaceData>>> = _places.asSharedFlow()
+
+    private val _message = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val message: SharedFlow<String> = _message.asSharedFlow()
+
+    init {
+        observeSearchQuery()
+    }
+
+    fun updateSearchQuery(query: String) {
+        _searchQuery.value = query
+    }
+
+    @OptIn(FlowPreview::class)
+    private fun observeSearchQuery() {
+        _searchQuery
+            .debounce(500)
+            .filter { it.isNotEmpty() }
+            .onEach { fetchPlacePredictions(it) }
+            .launchIn(viewModelScope)
+    }
+
+    private fun fetchPlacePredictions(query: String) {
+        viewModelScope.launch { _places.emit(Response.Loading) }
+
+        val request = FindAutocompletePredictionsRequest.builder()
+            .setQuery(query)
+            .setSessionToken(sessionToken)
+            .setCountries("EG")
+            .build()
+
+        placesClient.findAutocompletePredictions(request)
+            .addOnSuccessListener { response ->
+                val predictions = response.autocompletePredictions.map { prediction ->
+                    PlaceData(
+                        placeId = prediction.placeId,
+                        displayName = prediction.getPrimaryText(null).toString(),
+                        address = prediction.getFullText(null).toString()
+                    )
+                }
+                viewModelScope.launch { _places.emit(Response.Success(predictions)) }
+            }
+            .addOnFailureListener { exception ->
+                handleFailure("Error fetching predictions", exception)
+            }
+    }
+
+    suspend fun fetchPlaceDetails(placeId: String): Pair<Double, Double>? {
+        return try {
+            val request = FetchPlaceRequest.builder(
+                placeId,
+                listOf(Place.Field.LAT_LNG, Place.Field.NAME, Place.Field.ADDRESS)
+            ).build()
+
+            val response = placesClient.fetchPlace(request).await()
+
+            val place = response.place
+            val placeData = PlaceData(
+                placeId = placeId,
+                displayName = place.name ?: "Unknown",
+                latLng = place.latLng,
+                address = place.address
+            )
+
+            place.latLng?.let { Pair(it.latitude, it.longitude) }
+        } catch (exception: Exception) {
+            handleFailure("Error fetching place details", exception)
+            null
+        }
+    }
+
+
+    private fun handleFailure(message: String, exception: Exception) {
+        Log.e("SearchViewModel", "$message: ${exception.localizedMessage}")
+        viewModelScope.launch {
+            _places.emit(Response.Failure(exception))
+            _message.emit("$message: ${exception.localizedMessage ?: "Unknown error"}")
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/weathersync/viewmodel/SearchViewModelFactory.kt
+++ b/app/src/main/java/com/example/weathersync/viewmodel/SearchViewModelFactory.kt
@@ -1,0 +1,15 @@
+package com.example.weathersync.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.weathersync.data.remote.RetrofitClient
+
+class SearchViewModelFactory (private val context: Context) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(SearchViewModel::class.java)) {
+            return SearchViewModel(context) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
- Add `SearchViewModelFactory` for creating `SearchViewModel`.
- Refactor `SearchScreen` to utilize `SearchViewModel` for place searching.
- Fetch and display place predictions using the Places API.
- Implement place details retrieval for the selected place using `fetchPlaceDetails`.
- Create `PlaceData` data class to represent place details.
- Refactor `MapScreenRoute` to take lat and lon as parameters.
- Navigate to `MapScreen` with selected place's coordinates.
- Improve search result item UI to support both LTR and RTL languages.
- Handle SnackBar to display when the user save the location in favorites.
- Handle place search responses (loading, success, failure) and display results accordingly.
- Handle remove map marker when selecting another location.
- Update `WEATHER_BASE_URL` for weather API requests.
- Update google places dependency to 3.4.0