### PR TITLE
Improve language handling and add database migration

### DIFF
--- a/app/src/main/java/com/example/weathersync/data/local/WeatherDataBase.kt
+++ b/app/src/main/java/com/example/weathersync/data/local/WeatherDataBase.kt
@@ -32,7 +32,8 @@ abstract class WeatherDatabase : RoomDatabase() {
                     context.applicationContext,
                     WeatherDatabase::class.java,
                     "weather_database"
-                ).build()
+                ).fallbackToDestructiveMigration()
+                    .build()
                 instance = INSTANCE
                 INSTANCE
             }

--- a/app/src/main/java/com/example/weathersync/utils/LocaleHelper.kt
+++ b/app/src/main/java/com/example/weathersync/utils/LocaleHelper.kt
@@ -4,28 +4,50 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Configuration
 import android.os.Build
+import android.util.Log
 import com.example.weathersync.R
 import java.util.Locale
 
 object LocaleHelper {
     fun setLocale(context: Context, language: String): Context {
-        SharedPreferencesHelper.saveSetting(context, SharedPreferencesHelper.KEY_LANGUAGE, language)
+        //SharedPreferencesHelper.saveSetting(context, SharedPreferencesHelper.KEY_LANGUAGE, language)
+        Log.d("LocaleHelper", "Setting language to: $language")
         return updateResources(context, language)
     }
 
     fun onAttach(context: Context): Context {
-        val language = SharedPreferencesHelper.getSetting(context, SharedPreferencesHelper.KEY_LANGUAGE)
-            .ifEmpty { context.getString(R.string.default_language) }
+        var language = SharedPreferencesHelper.getSetting(context, SharedPreferencesHelper.KEY_LANGUAGE)
+        /*if (language == "Default"){
+            val defaultLanguage = context.resources.configuration.locales[0].language
+            if (defaultLanguage == "ar") {
+                 language = "Arabic"
+            } else {
+                language = "English"
+            }
+        }*/
+        Log.d("LocaleHelper", "Attaching language: $language")
         return updateResources(context, language)
+    }
+
+    fun covert(st : String) : Locale {
+        if(st == "ar"){
+            return Locale("ar")
+        }
+        else
+            return Locale("en")
+
     }
 
     @SuppressLint("ObsoleteSdkInt")
     private fun updateResources(context: Context, language: String): Context {
+        Log.d("LocaleHelper", "Updating language to: $language")
         val locale = when (language) {
-            context.getString(R.string.arabic) -> Locale("ar")
-            context.getString(R.string.english) -> Locale("en")
-            else -> Locale.getDefault()
+            "Arabic" -> Locale("ar")
+            "English" -> Locale("en")
+            "Default" -> covert(context.resources.configuration.locales[0].language)
+            else -> Locale("en")
         }
+        Log.d("LocaleHelper", "Selected locale: $locale")
 
         Locale.setDefault(locale)
         val config = Configuration(context.resources.configuration)

--- a/app/src/main/java/com/example/weathersync/utils/WeatherUtils.kt
+++ b/app/src/main/java/com/example/weathersync/utils/WeatherUtils.kt
@@ -19,6 +19,7 @@ object WeatherUtils {
         val languageCode = when (languageSetting.lowercase(Locale.ROOT)) {
             "arabic" -> "ar"
             "english" -> "en"
+            "default" -> context.resources.configuration.locales[0].language
             else -> "en"
         }
         val weatherDescriptions = mapOf(
@@ -111,15 +112,6 @@ object WeatherUtils {
         return dateFormat.format(Date())
     }
 
-    fun getFormattedTime(context: Context): String {
-        val languageCode = SharedPreferencesHelper.getSetting(context, SharedPreferencesHelper.KEY_LANGUAGE)
-        val locale = Locale(languageCode)
-        val timeFormat = SimpleDateFormat("hh:mm a", locale)
-
-        return timeFormat.format(Date())
-    }
-
-
     fun getFormattedDate(context: Context): String {
         val languageCode = SharedPreferencesHelper.getSetting(context, SharedPreferencesHelper.KEY_LANGUAGE)
         val locale = Locale(languageCode)
@@ -147,6 +139,7 @@ object WeatherUtils {
         val languageCode = when (languageSetting.lowercase(Locale.ROOT)) {
             "arabic" -> "ar"
             "english" -> "en"
+            "default" -> context.resources.configuration.locales[0].language
             else -> "en"
         }
 
@@ -164,6 +157,7 @@ object WeatherUtils {
         val languageCode = when (languageSetting.lowercase(Locale.ROOT)) {
             "arabic" -> "ar"
             "english" -> "en"
+            "default" -> context.resources.configuration.locales[0].language
             else -> "en"
         }
         return if (languageCode == "ar") {
@@ -196,6 +190,8 @@ object WeatherUtils {
 
             when (languageSetting) {
                 "arabic" -> SimpleDateFormat("EEEE", Locale("ar", "SA")).format(parsedDate)
+                "english" -> SimpleDateFormat("EEEE", Locale.ENGLISH).format(parsedDate)
+                "default" -> SimpleDateFormat("EEEE", context.resources.configuration.locales[0]).format(parsedDate)
                 else -> SimpleDateFormat("EEEE", Locale.ENGLISH).format(parsedDate)
             }
         } catch (e: Exception) {


### PR DESCRIPTION
- Updated `LocaleHelper` to support a "Default" language option that dynamically selects the system's default language.
- Modified `WeatherUtils` to use the system's default language when "Default" is selected in settings.
- Added `fallbackToDestructiveMigration()` to the database builder to handle schema changes in future updates.